### PR TITLE
QoL: Filter by met requirements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.28'
+def runeLiteVersion = '1.6.36.2'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.optimalquestguide'
-version = '2.1-SNAPSHOT'
+version = '2.2-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/optimalquestguide/GuideConfig.java
+++ b/src/main/java/com/optimalquestguide/GuideConfig.java
@@ -67,6 +67,13 @@ public interface GuideConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "filterMetRequirements",
+            name = "Filter by met Requirements",
+            description = "Only display the quests that you have the met requirements to complete"
+    )
+    default boolean filterMetRequirements() { return false; }
+
+    @ConfigItem(
             keyName = "inProgressColor",
             name = "Quest in progress color",
             description = "Color of Quests in progress",


### PR DESCRIPTION
As the name implies. Plugin will now filter by met requirements and hide all that are currently unmet.

The option to `show all completed quests` will override this setting and display all quests still.