### PR TITLE
Add quest Beneath Cursed Sands

### DIFF
--- a/src/main/resources/quests.json
+++ b/src/main/resources/quests.json
@@ -2154,6 +2154,27 @@
         ]
     },
     {
+        "name": "Beneath Cursed Sands",
+        "uri": "https://oldschool.runescape.wiki/w/Beneath_Cursed_Sands",
+        "reqs": [
+            {
+                "skill": "Agility",
+                "level": "62",
+                "boostable": false
+            },
+            {
+                "skill": "Crafting",
+                "level": "55",
+                "boostable": false
+            },
+            {
+                "skill": "Firemaking",
+                "level": "55",
+                "boostable": false
+            }
+        ]
+    },
+    {
         "name": "Making Friends with My Arm",
         "uri": "https://oldschool.runescape.wiki/w/Making_Friends_with_My_Arm",
         "reqs": [


### PR DESCRIPTION
This PR adds the quest [Beneath Cursed Sands](https://oldschool.runescape.wiki/w/Beneath_Cursed_Sands). Fixes #32. I haven't run the plugin with the change so the RuneLite version might need to be bumped to enable all the integrations, such as auto-update on completion.