### PR TITLE
Add new quests from the "Varlamore: The Final Dawn" update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.optimalquestguide'
-version = '2.7-SNAPSHOT'
+version = '2.8-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/resources/quests.json
+++ b/src/main/resources/quests.json
@@ -2371,6 +2371,53 @@
         "reqs": []
     },
     {
+        "name": "Scrambled!",
+        "uri": "https://oldschool.runescape.wiki/w/Scrambled!",
+        "reqs": [
+            {
+                "skill": "Construction",
+                "level": 38,
+                "boostable": false
+            },
+            {
+                "skill": "Cooking",
+                "level": 36,
+                "boostable": false
+            },
+            {
+                "skill": "Construction",
+                "level": 38,
+                "boostable": false
+            },
+        ]
+    },
+    {
+        "name": "Shadows of Custodia",
+        "uri": "https://oldschool.runescape.wiki/w/Shadows_of_Custodia",
+        "reqs": [
+            {
+                "skill": "Construction",
+                "level": 41,
+                "boostable": false
+            },
+            {
+                "skill": "Fishing",
+                "level": 45,
+                "boostable": false
+            },
+            {
+                "skill": "Hunter",
+                "level": 36,
+                "boostable": false
+            },
+            {
+                "skill": "Slayer",
+                "level": 54,
+                "boostable": false
+            },
+        ]
+    },
+    {
         "name": "Dragon Slayer II",
         "uri": "https://oldschool.runescape.wiki/w/Dragon_Slayer_II",
         "reqs": [
@@ -2500,6 +2547,27 @@
             {
                 "skill": "Thieving",
                 "level": 64,
+                "boostable": false
+            }
+        ]
+    },
+    {
+        "name": "The Final Dawn",
+        "uri": "https://oldschool.runescape.wiki/w/The_Final_Dawn",
+        "reqs": [
+            { 
+                "skill": "Fletching",
+                "level": 52,
+                "boostable": false
+            },
+            { 
+                "skill": "Runecraft",
+                "level": 52,
+                "boostable": false
+            },
+            { 
+                "skill": "Thieving",
+                "level": 66,
                 "boostable": false
             }
         ]
@@ -2641,26 +2709,5 @@
         "name": "The Corsair Curse",
         "uri": "https://oldschool.runescape.wiki/w/The_Corsair_Curse",
         "reqs": []
-    },
-    {
-        "name": "The Final Dawn",
-        "uri": "https://oldschool.runescape.wiki/w/The_Final_Dawn",
-        "reqs": [
-            { 
-                "skill": "Fletching",
-                "level": 52,
-                "boostable": false
-            },
-            { 
-                "skill": "Runecraft",
-                "level": 52,
-                "boostable": false
-            },
-            { 
-                "skill": "Thieving",
-                "level": 66,
-                "boostable": false
-            }
-        ]
     },
 ]

--- a/src/main/resources/quests.json
+++ b/src/main/resources/quests.json
@@ -2388,7 +2388,7 @@
                 "skill": "Construction",
                 "level": 38,
                 "boostable": false
-            },
+            }
         ]
     },
     {
@@ -2414,7 +2414,7 @@
                 "skill": "Slayer",
                 "level": 54,
                 "boostable": false
-            },
+            }
         ]
     },
     {
@@ -2709,5 +2709,5 @@
         "name": "The Corsair Curse",
         "uri": "https://oldschool.runescape.wiki/w/The_Corsair_Curse",
         "reqs": []
-    },
+    }
 ]

--- a/src/main/resources/quests.json
+++ b/src/main/resources/quests.json
@@ -2641,5 +2641,26 @@
         "name": "The Corsair Curse",
         "uri": "https://oldschool.runescape.wiki/w/The_Corsair_Curse",
         "reqs": []
-    }
+    },
+    {
+        "name": "The Final Dawn",
+        "uri": "https://oldschool.runescape.wiki/w/The_Final_Dawn",
+        "reqs": [
+            { 
+                "skill": "Fletching",
+                "level": 52,
+                "boostable": false
+            },
+            { 
+                "skill": "Runecraft",
+                "level": 52,
+                "boostable": false
+            },
+            { 
+                "skill": "Thieving",
+                "level": 66,
+                "boostable": false
+            }
+        ]
+    },
 ]


### PR DESCRIPTION
This PR adds these three new quests to the plugin, in the order in which they currently appear in the wiki's Optimal quest guide:

- Scrambled!
- Shadows of Custodia
- The Final Dawn